### PR TITLE
Escape drone variables

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -15,9 +15,9 @@ pipeline:
       - DOCKER_HOST=tcp://172.17.0.1:2375
     commands:
       - docker build -t html-pdf-converter .
-      - docker login -u="ukhomeofficedigital+html_pdf_converter" -p=${DOCKER_PASSWORD} quay.io
-      - docker tag html-pdf-converter quay.io/ukhomeofficedigital/html-pdf-converter:${DRONE_COMMIT_SHA}
-      - docker push quay.io/ukhomeofficedigital/html-pdf-converter:${DRONE_COMMIT_SHA}
+      - docker login -u="ukhomeofficedigital+html_pdf_converter" -p=$${DOCKER_PASSWORD} quay.io
+      - docker tag html-pdf-converter quay.io/ukhomeofficedigital/html-pdf-converter:$${DRONE_COMMIT_SHA}
+      - docker push quay.io/ukhomeofficedigital/html-pdf-converter:$${DRONE_COMMIT_SHA}
     when:
       branch: master
       event: push


### PR DESCRIPTION
In migrating to new drone, the docker login is no longer working. Comparing with working builds, the secrets need to be escaped (double-dollar).