### PR TITLE
Increase body size limit

### DIFF
--- a/config.js
+++ b/config.js
@@ -5,7 +5,8 @@ const config = {
   port: process.env.APP_PORT || 8001,
   host: process.env.APP_HOST || 'localhost',
   env: process.env.NODE_ENV,
-  loglevel: process.env.LOG_LEVEL
+  loglevel: process.env.LOG_LEVEL,
+  limit: process.env.BODY_SIZE_LIMIT || '2mb'
 };
 
 module.exports = config;

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const errorHandler = require('./middleware/error-handler');
 
 app.use(churchill(logger));
 
-app.use(bodyParser.json({ limit: '2mb' }));
+app.use(bodyParser.json({ limit: config.limit }));
 
 app.use('/convert', controller);
 app.use(errorHandler);

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const errorHandler = require('./middleware/error-handler');
 
 app.use(churchill(logger));
 
-app.use(bodyParser.json());
+app.use(bodyParser.json({ limit: '2mb' }));
 
 app.use('/convert', controller);
 app.use(errorHandler);


### PR DESCRIPTION
The default limit of the json body parser is 100kb, which does not allow for rendering large documents.

Increase the limit to 2mb to be in line with the default nginx body size limit.