### PR TITLE
Prefix debug namespace with `pdf`

### DIFF
--- a/controllers/convert.js
+++ b/controllers/convert.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const router = require('express').Router();
-const debug = require('debug')('controllers:index');
+const debug = require('debug')('pdf:controllers:index');
 const render = require('../middleware/render');
 const validate = require('../middleware/validate');
 const Model = require('../models/converter');

--- a/middleware/error-handler.js
+++ b/middleware/error-handler.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const debug = require('debug')('middleware:errorhandler');
+const debug = require('debug')('pdf:middleware:errorhandler');
 
 // eslint-disable-next-line no-unused-vars
 module.exports = (error, req, res, next) => {

--- a/middleware/render.js
+++ b/middleware/render.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const debug = require('debug')('middleware:render');
+const debug = require('debug')('pdf:middleware:render');
 const mustache = require('mustache');
 
 module.exports = (req, res, next) => {

--- a/middleware/validate.js
+++ b/middleware/validate.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const missingData = require('../lib/missing-data');
-const debug = require('debug')('middleware:validate');
+const debug = require('debug')('pdf:middleware:validate');
 const ValidationError = require('../lib/validation-error');
 
 module.exports = (req, res, next) => {

--- a/test/mocha-opts
+++ b/test/mocha-opts
@@ -1,3 +1,0 @@
---require test/common.js
---recursive
---reporter spec


### PR DESCRIPTION
This allows all debug for this module to be switched on without needing to set `DEBUG=*` which also turns on debug for other modules - in particular express router and mocha, which make a lot of noise while running unit tests.