### PR TITLE
Add pdf options

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,21 @@ Response (example)
 %PDF-1.4\n1 0 obj\n<<\n/Title ...
 ```
 
+## PDF Options
+
+Chrome can accept a number of options to its PDF render function. These are documented here: [https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagepdfoptions](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagepdfoptions)
+
+These can be set on a per-request basis by passing a `pdfOptions` object as part of your request body.
+
+```json
+{
+  "template":"<h1>Hello World!</h1>",
+  "pdfOptions": {
+    "printBackground": true
+  }
+}
+```
+
 ## External Resources
 
 This service cannot resolve external resources such as linked CSS, JavaScript or images.

--- a/controllers/convert.js
+++ b/controllers/convert.js
@@ -17,7 +17,7 @@ module.exports = router.post('/',
 
     req.log('debug', 'Creating PDF');
 
-    model.create(res.locals.html).then(data => {
+    model.create(res.locals.html, req.body.pdfOptions).then(data => {
       req.log('debug', 'Created PDF');
       res.setHeader('Content-Type', 'octet-stream');
       res.status(201).send(data);

--- a/controllers/convert.js
+++ b/controllers/convert.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const router = require('express').Router();
-const debug = require('debug')('controllers:index');
+const debug = require('debug')('pdf:controllers:index');
 const render = require('../middleware/render');
 const validate = require('../middleware/validate');
 const Model = require('../models/converter');

--- a/middleware/error-handler.js
+++ b/middleware/error-handler.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const debug = require('debug')('middleware:errorhandler');
+const debug = require('debug')('pdf:middleware:errorhandler');
 
 // eslint-disable-next-line no-unused-vars
 module.exports = (error, req, res, next) => {

--- a/middleware/render.js
+++ b/middleware/render.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const debug = require('debug')('middleware:render');
+const debug = require('debug')('pdf:middleware:render');
 const mustache = require('mustache');
 
 module.exports = (req, res, next) => {

--- a/middleware/validate.js
+++ b/middleware/validate.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const missingData = require('../lib/missing-data');
-const debug = require('debug')('middleware:validate');
+const debug = require('debug')('pdf:middleware:validate');
 const ValidationError = require('../lib/validation-error');
 
 module.exports = (req, res, next) => {

--- a/models/converter.js
+++ b/models/converter.js
@@ -4,7 +4,7 @@ const puppeteer = require('puppeteer');
 
 module.exports = class PDFConverterModel {
 
-  create(html) {
+  create(html, options) {
 
     const opts = {
       args: [
@@ -12,12 +12,17 @@ module.exports = class PDFConverterModel {
           '--disable-setuid-sandbox'
       ]
     };
+
+    options = Object.assign({
+      format: 'A4'
+    }, options);
+
     return puppeteer.launch(opts)
       .then(browser => {
         return browser.newPage()
           .then(page => {
             return page.goto(`data:text/html,${html}`, {waitUntil: 'networkidle2' })
-              .then(() => page.pdf({ format: 'A4' }))
+              .then(() => page.pdf(options))
               .then(data => Buffer.from(data, 'base64'));
           })
           .then(data => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -216,6 +216,53 @@
         "supports-color": "2.0.0"
       }
     },
+    "choma": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/choma/-/choma-1.2.0.tgz",
+      "integrity": "sha512-nl9VE8maFvY95SPHEdJ/avEsBJ4gcgZ4M7r1tA7HtBAhUsVn74OnVYsB65l6xGXYOakMkJCp/lmv+4vfknIZ4Q==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.2",
+        "seedrandom": "2.4.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
     "churchill": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/churchill/-/churchill-1.1.1.tgz",
@@ -252,6 +299,21 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "colors": {
@@ -813,16 +875,6 @@
         "object-assign": "4.1.1"
       }
     },
-    "fill-keys": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
-      "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
-      "dev": true,
-      "requires": {
-        "is-object": "1.0.1",
-        "merge-descriptors": "1.0.1"
-      }
-    },
     "finalhandler": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
@@ -1137,12 +1189,6 @@
         "jsonpointer": "4.0.1",
         "xtend": "4.0.1"
       }
-    },
-    "is-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
-      "dev": true
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -1480,12 +1526,6 @@
         }
       }
     },
-    "module-not-found-error": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
-      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
-      "dev": true
-    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -1680,25 +1720,6 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
       "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4="
     },
-    "proxyquire": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.8.0.tgz",
-      "integrity": "sha1-AtUUpb7ZhvBMuyCTrxZ0FTX3ntw=",
-      "dev": true,
-      "requires": {
-        "fill-keys": "1.0.2",
-        "module-not-found-error": "1.0.1",
-        "resolve": "1.1.7"
-      },
-      "dependencies": {
-        "resolve": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-          "dev": true
-        }
-      }
-    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -1855,6 +1876,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
       "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "dev": true
+    },
+    "seedrandom": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.3.tgz",
+      "integrity": "sha1-JDhQTa0zkXMUv/GKxNeU8W1qrsw=",
       "dev": true
     },
     "send": {

--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
     "puppeteer": "^1.1.1"
   },
   "devDependencies": {
+    "choma": "^1.2.0",
     "eslint": "^3.14.0",
     "eslint-config-homeoffice": "^2.1.0",
     "mocha": "^3.2.0",
     "pre-commit": "^1.2.2",
-    "proxyquire": "^1.7.11",
     "sinon": "^2.1.0",
     "supertest": "^3.0.0"
   },

--- a/test/mocha-opts
+++ b/test/mocha-opts
@@ -1,3 +1,0 @@
---require test/common.js
---recursive
---reporter spec

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,3 @@
 --require test/common.js
 --recursive
 --reporter spec
---require choma

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,4 @@
 --require test/common.js
 --recursive
 --reporter spec
+--require choma


### PR DESCRIPTION
This allows clients to pass [options](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagepdfoptions) to chrome's `pdf` method to control some of the settings it uses.

It also cleans up some of the unit tests that had slightly flaky stubs, which came out of my abandoned regression test suite attempt.