### PR TITLE
Allow for a custom "waituntil" option on page load

### DIFF
--- a/models/converter.js
+++ b/models/converter.js
@@ -15,7 +15,7 @@ module.exports = class PDFConverterModel {
 
     options = Object.assign({
       format: 'A4',
-      waitUntil: 'networkidle2'
+      waitUntil: 'load'
     }, options);
 
     return puppeteer.launch(opts)

--- a/models/converter.js
+++ b/models/converter.js
@@ -14,14 +14,15 @@ module.exports = class PDFConverterModel {
     };
 
     options = Object.assign({
-      format: 'A4'
+      format: 'A4',
+      waitUntil: 'networkidle2'
     }, options);
 
     return puppeteer.launch(opts)
       .then(browser => {
         return browser.newPage()
           .then(page => {
-            return page.goto(`data:text/html,${html}`, {waitUntil: 'networkidle2' })
+            return page.goto(`data:text/html,${html}`, { waitUntil: options.waitUntil })
               .then(() => page.pdf(options))
               .then(data => Buffer.from(data, 'base64'));
           })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1727,9 +1727,9 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.1.1.tgz",
-      "integrity": "sha1-rb8l5J9e8DRDwQq44JqVTKDHv+4=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.2.0.tgz",
+      "integrity": "sha512-4sY/6mB7+kNPGAzPGKq65tH0VG3ohUEkXHuOReB9K/tw3m1TqifYmxnMR/uDeci/UPwyk5K1gWYh8rw0U0Zscw==",
       "requires": {
         "debug": "2.6.9",
         "extract-zip": "1.6.6",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "hof-logger": "2.0.0",
     "lodash": "^4.17.4",
     "mustache": "^2.3.0",
-    "puppeteer": "^1.1.1"
+    "puppeteer": "^1.2.0"
   },
   "devDependencies": {
     "choma": "^1.2.0",

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -155,16 +155,16 @@ describe('POSTing to /convert', () => {
     it('respects custom waitUntil option if defined', () => {
       return supertest(require('../../'))
         .post('/convert')
-        .send({ template: template, pdfOptions: { waitUntil: 'load' } })
+        .send({ template: template, pdfOptions: { waitUntil: 'networkidle0' } })
         .expect(201)
         .expect('Content-type', /octet-stream/)
         .expect(() => {
           assert(gotoStub.calledOnce);
-          assert(gotoStub.calledWith(sinon.match.string, { waitUntil: 'load' }));
+          assert(gotoStub.calledWith(sinon.match.string, { waitUntil: 'networkidle0' }));
         });
     });
 
-    it('waits for networkidle2 event by default', () => {
+    it('waits for load event by default', () => {
       return supertest(require('../../'))
         .post('/convert')
         .send({ template: template })
@@ -172,7 +172,7 @@ describe('POSTing to /convert', () => {
         .expect('Content-type', /octet-stream/)
         .expect(() => {
           assert(gotoStub.calledOnce);
-          assert(gotoStub.calledWith(sinon.match.string, { waitUntil: 'networkidle2' }));
+          assert(gotoStub.calledWith(sinon.match.string, { waitUntil: 'load' }));
         });
     });
 

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -16,13 +16,15 @@ const result = Buffer(1);
 describe('POSTing to /convert', () => {
 
   let pdfStub;
+  let gotoStub;
 
   beforeEach(() => {
     pdfStub = sinon.stub().resolves(result);
+    gotoStub = sinon.stub().resolves();
     const clientStub = {
       close: sinon.stub().resolves(),
       newPage: sinon.stub().resolves({
-        goto: sinon.stub().resolves(),
+        goto: gotoStub,
         pdf: pdfStub
       })
     };
@@ -146,7 +148,31 @@ describe('POSTing to /convert', () => {
         .expect('Content-type', /octet-stream/)
         .expect(() => {
           assert(pdfStub.calledOnce);
-          assert(pdfStub.calledWithExactly({ format: 'A4', printBackgrounds: true }));
+          assert(pdfStub.calledWith(sinon.match({ format: 'A4', printBackgrounds: true })));
+        });
+    });
+
+    it('respects custom waitUntil option if defined', () => {
+      return supertest(require('../../'))
+        .post('/convert')
+        .send({ template: template, pdfOptions: { waitUntil: 'load' } })
+        .expect(201)
+        .expect('Content-type', /octet-stream/)
+        .expect(() => {
+          assert(gotoStub.calledOnce);
+          assert(gotoStub.calledWith(sinon.match.string, { waitUntil: 'load' }));
+        });
+    });
+
+    it('waits for networkidle2 event by default', () => {
+      return supertest(require('../../'))
+        .post('/convert')
+        .send({ template: template })
+        .expect(201)
+        .expect('Content-type', /octet-stream/)
+        .expect(() => {
+          assert(gotoStub.calledOnce);
+          assert(gotoStub.calledWith(sinon.match.string, { waitUntil: 'networkidle2' }));
         });
     });
 


### PR DESCRIPTION
If rendering a page that loads external assets then `waitUntil` using `networkidle2` is insufficient as it renders before all assets are loaded.

Instead allow for a custom `waitUntil` option to be included, so that pages loading assets can force wait for those assets to load - either `networkidle0` or `load`.