### PR TITLE
Use uid for user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,6 @@ RUN chown -R nodejs:nodejs /app/node_modules/puppeteer
 
 COPY . /app
 
-USER nodejs
+USER 999
 
 CMD ["npm", "start"]


### PR DESCRIPTION
Images need to run with a numeric uid, and not a username.

As per https://github.com/UKHomeOffice/application-container-platform/blob/master/how-to-docs/pod-security-policies.md#runasuser