### PR TITLE
Add the conversion controller to root url

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ app.use(churchill(logger));
 app.use(bodyParser.json({ limit: config.limit }));
 
 app.use('/convert', controller);
+app.use('/', controller);
 app.use(errorHandler);
 app.listen(config.port, () => {
   // eslint-disable-next-line no-console


### PR DESCRIPTION
To make configuring upstream services a little bit easier, don't require `/convert` to be appended to the host.

Leaves the `/convert` path in place additionally to remain backwards compatible.