### PR TITLE
Use setContent instead of data urls

### DIFF
--- a/models/converter.js
+++ b/models/converter.js
@@ -22,7 +22,7 @@ module.exports = class PDFConverterModel {
       .then(browser => {
         return browser.newPage()
           .then(page => {
-            return page.goto(`data:text/html,${html}`, { waitUntil: options.waitUntil })
+            return page.setContent(html, { waitUntil: options.waitUntil })
               .then(() => page.pdf(options))
               .then(data => Buffer.from(data, 'base64'));
           })

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -16,15 +16,15 @@ const result = Buffer(1);
 describe('POSTing to /convert', () => {
 
   let pdfStub;
-  let gotoStub;
+  let setContentStub;
 
   beforeEach(() => {
     pdfStub = sinon.stub().resolves(result);
-    gotoStub = sinon.stub().resolves();
+    setContentStub = sinon.stub().resolves();
     const clientStub = {
       close: sinon.stub().resolves(),
       newPage: sinon.stub().resolves({
-        goto: gotoStub,
+        setContent: setContentStub,
         pdf: pdfStub
       })
     };
@@ -159,8 +159,8 @@ describe('POSTing to /convert', () => {
         .expect(201)
         .expect('Content-type', /octet-stream/)
         .expect(() => {
-          assert(gotoStub.calledOnce);
-          assert(gotoStub.calledWith(sinon.match.string, { waitUntil: 'networkidle0' }));
+          assert(setContentStub.calledOnce);
+          assert(setContentStub.calledWith(sinon.match.string, { waitUntil: 'networkidle0' }));
         });
     });
 
@@ -171,8 +171,8 @@ describe('POSTing to /convert', () => {
         .expect(201)
         .expect('Content-type', /octet-stream/)
         .expect(() => {
-          assert(gotoStub.calledOnce);
-          assert(gotoStub.calledWith(sinon.match.string, { waitUntil: 'load' }));
+          assert(setContentStub.calledOnce);
+          assert(setContentStub.calledWith(sinon.match.string, { waitUntil: 'load' }));
         });
     });
 


### PR DESCRIPTION
The new versions of puppeteer add a `setContent` method for doing exactly what we are trying to do here. Also the data urls fail to render properly.