### PR TITLE
Disable mustache render where there is nothing to render

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,8 +1,8 @@
 pipeline:
   test:
-    image: node:8
+    image: node:10
     commands:
-      - npm --loglevel warn install
+      - npm ci
       - npm test
     when:
       event: [push, pull_request, tag]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
 FROM node:10-slim
 
-RUN  apt-get update \
-     # See https://crbug.com/795759
-     && apt-get install -yq libgconf-2-4 \
-     # Install latest chrome dev package, which installs the necessary libs to
-     # make the bundled version of Chromium that Puppeteer installs work.
-     && apt-get install -y wget --no-install-recommends \
-     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-     && apt-get update \
-     && apt-get install -y google-chrome-unstable --no-install-recommends
+RUN  apt-get update
+# See https://crbug.com/795759
+RUN apt-get install -yq libgconf-2-4
+RUN apt-get install -yq gnupg
+# Install latest chrome dev package, which installs the necessary libs to
+# make the bundled version of Chromium that Puppeteer installs work.
+RUN apt-get install -y curl --no-install-recommends
+RUN curl -k https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
+RUN apt-get update
+RUN apt-get install -y google-chrome-unstable --no-install-recommends
 
 RUN addgroup --system app
 RUN adduser --system app --uid 999 --home /app/

--- a/middleware/render.js
+++ b/middleware/render.js
@@ -7,6 +7,10 @@ module.exports = (req, res, next) => {
   req.log('debug', 'Rendering HTML');
   const template = req.body.template;
   const data = req.body.data;
+  if (!data || req.body.noRender) {
+    res.locals.html = template;
+    return next();
+  }
   try {
     debug('Rendering %s', template);
     const rendered = mustache.render(template, data);

--- a/middleware/validate.js
+++ b/middleware/validate.js
@@ -5,6 +5,9 @@ const debug = require('debug')('pdf:middleware:validate');
 const ValidationError = require('../lib/validation-error');
 
 module.exports = (req, res, next) => {
+  if (req.body.noRender) {
+    return next();
+  }
   req.log('debug', 'Validating request');
   const template = req.body.template;
   let missing;

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -106,13 +106,13 @@ describe('POSTing to /convert', () => {
 
   describe('with a valid html string', () => {
 
-    it('renders the html', () => {
+    it('renders the html without calling a mustache render', () => {
       return supertest(App)
         .post('/convert')
         .send({template: template})
         .expect(201)
         .expect('Content-type', /octet-stream/)
-        .expect(() => assert(mustache.render.calledOnce));
+        .expect(() => assert(!mustache.render.called));
     });
 
     it('returns a 201 and a PDF', () => {


### PR DESCRIPTION
Converting the entire HTML to a mustache template where there is no data passed uses a huge amount of memory to do a no-op.

Skip the mustache rendering if no data is passed.