### PR TITLE
Disable shm in puppeteer

### DIFF
--- a/models/converter.js
+++ b/models/converter.js
@@ -9,7 +9,8 @@ module.exports = class PDFConverterModel {
     const opts = {
       args: [
           '--no-sandbox',
-          '--disable-setuid-sandbox'
+          '--disable-setuid-sandbox',
+          '--disable-dev-shm-usage'
       ]
     };
 


### PR DESCRIPTION
By default docker runs with 64 of shared memory in `/dev/shm`, which is not enough for Chrome to render large pages. By disabling shm when starting puppeteer it writes to `/tmp` instead which has no such limits.

See https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#tips for details.