### PR TITLE
Add unhandled rejections flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ RUN chown -R app:app /app/node_modules/puppeteer
 
 COPY . /app
 
-CMD node index.js
+CMD node index.js --unhandled-rejections=strict


### PR DESCRIPTION
Chrome occasionally crashes on teardown and emits an unhandled promise rejection warning. When this occurs it leaves some resources in memory. Eventually this results in running out of memory and failed requests.

By adding this flag the process will restart completely if and when the unhandled promise rejection occurs, and will therefore not continue to consume excess memory.