### PR TITLE
fix: .env PORT value was not being picked up

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,4 +1,10 @@
 'use strict';
+try {
+  // eslint-disable-next-line implicit-dependencies/no-implicit
+  require('dotenv').config();
+} catch (e) {
+  // noop
+}
 
 /* eslint-disable no-process-env */
 const config = {


### PR DESCRIPTION
When running locally alongside ASL, the default PORT value (8080) conflicts with other services.

Specifying a PORT in `.env` was not being picked up without this code.