### PR TITLE
HOF-405: Added trivy scanner to html-pdf-converter

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -42,12 +42,31 @@ steps:
       - docker push quay.io/ukhomeofficedigital/html-pdf-converter:$${DRONE_TAG}
     when:
       event: tag
+     # Trivy Security Scannner
+  - name: scan-image
+    pull: always
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
+    resources:
+      limits:
+        cpu: 1000
+        memory: 1024Mi
+    environment:
+      IMAGE_NAME: html-pdf-converter:${DRONE_COMMIT_SHA}
+      TOLERATE: MEDIUM,HIGH,CRITICAL
+      FAIL_ON_DETECTION: false
+      IGNORE_UNFIXED: true
+      ALLOW_CVE_LIST_FILE: hof-services-config/html-pdf-converter/trivy-cve-exceptions.txt
+    when:
+      event:
+      - pull_request
+      - push
+      - tag
 
 services:
 - name: docker
   image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
-- name: anchore-submission-server
-  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/anchore-submission:latest
+# - name: anchore-submission-server
+#   image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/anchore-submission:latest
   pull: always
   commands:
     - /run.sh server


### PR DESCRIPTION
# WHAT?
replaced anchore with trivy
# WHY?
 trivy scans docker base image for vulnerability
 quick vulnerability scanning
