### PR TITLE
HOFF-405: Remove Tags as there is risk of overwriting

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -76,7 +76,7 @@ steps:
         from_secret: docker_password
     commands:
       - docker login -u="ukhomeofficedigital+html_pdf_converter" -p=$${DOCKER_PASSWORD} quay.io
-      - docker tag $${IMAGE_REPO}:$${DRONE_COMMIT_SHA} $${IMAGE_URL}/$${IMAGE_REPO}:$${VERSION}
+      - docker tag $${IMAGE_REPO}:$${DRONE_COMMIT_SHA} $${IMAGE_URL}/$${IMAGE_REPO}:$${DRONE_COMMIT_SHA}
       - docker push $${IMAGE_URL}/$${IMAGE_REPO}:$${DRONE_COMMIT_SHA}
     when:
       branch:

--- a/.drone.yml
+++ b/.drone.yml
@@ -77,7 +77,7 @@ steps:
     commands:
       - docker login -u="ukhomeofficedigital+html_pdf_converter" -p=$${DOCKER_PASSWORD} quay.io
       - docker tag $${IMAGE_REPO}:$${DRONE_COMMIT_SHA} $${IMAGE_URL}/$${IMAGE_REPO}:$${VERSION}
-      - docker push $${IMAGE_URL}/$${IMAGE_REPO}:$${VERSION}
+      - docker push $${IMAGE_URL}/$${IMAGE_REPO}:$${DRONE_COMMIT_SHA}
     when:
       branch:
         include:


### PR DESCRIPTION
WHAT?

* High risk of over writing the digest sha and removing them
* Any developer with a PR can overwrite the tags

WHY?

* Revert back to using Drone Commit sha instead of tags
* These tags has to be added and pushed manually with Docker commands instead of executing from pipeline

HOW?

* Remove Tag from Push to Quay and replace with Drone Commit SHA
