### PR TITLE
HOFF-2153: Switch from Debian to Alpine Linux for security patch availability

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,7 +11,7 @@ environment:
 
 steps:
   - name: install
-    image: node:24-slim
+    image: node:24.18.0-alpine3.24@sha256:4ba75f835bb8802193e4c114572113d4b26f95f6f094f4b5229d2a77773e0afc
     commands:
       - yarn install
     when:
@@ -21,7 +21,7 @@ steps:
       event: [ push, pull_request, tag ]
 
   - name: test
-    image: node:24-slim
+    image: node:24.18.0-alpine3.24@sha256:4ba75f835bb8802193e4c114572113d4b26f95f6f094f4b5229d2a77773e0afc
     commands:
       - yarn test
     when:
@@ -54,9 +54,9 @@ steps:
         cpu: 1000
         memory: 1024Mi
     environment:
-      IMAGE_NAME: node:24-slim
+      IMAGE_NAME: node:24.18.0-alpine3.24@sha256:4ba75f835bb8802193e4c114572113d4b26f95f6f094f4b5229d2a77773e0afc
       SERVICE_URL: https://acp-trivy-helm.acp-trivy.svc.cluster.local:443 
-      TOLERATE: MEDIUM,HIGH,CRITICAL
+      TOLERATE: MEDIUM,HIGH,CRITICAL --vuln-type os,library
       FAIL_ON_DETECTION: false
       IGNORE_UNFIXED: true
       ALLOW_CVE_LIST_FILE: cve-exceptions.txt
@@ -95,7 +95,7 @@ steps:
     environment:
       IMAGE_NAME: html-pdf-converter:${DRONE_COMMIT_SHA}
       SERVICE_URL: https://acp-trivy-helm.acp-trivy.svc.cluster.local:443 
-      TOLERATE: MEDIUM,HIGH,CRITICAL
+      TOLERATE: MEDIUM,HIGH,CRITICAL --vuln-type os,library
       FAIL_ON_DETECTION: false
       IGNORE_UNFIXED: true
       ALLOW_CVE_LIST_FILE: cve-exceptions.txt

--- a/.drone.yml
+++ b/.drone.yml
@@ -9,6 +9,11 @@ environment:
 # Follow semantic versioning (e.g., v3.0.1 for patches, v3.1.0 for minor changes, v4.0.0 for major changes)
   VERSION: 3.1.0
 
+trigger:
+  branch:
+    include:
+    - master
+
 steps:
   - name: setup
     image: node:24.18.0-alpine3.24@sha256:4ba75f835bb8802193e4c114572113d4b26f95f6f094f4b5229d2a77773e0afc

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,10 +7,10 @@ environment:
   IMAGE_REPO: html-pdf-converter
 # Update the VERSION to a new value for significant changes or releases
 # Follow semantic versioning (e.g., v3.0.1 for patches, v3.1.0 for minor changes, v4.0.0 for major changes)
-  VERSION: 3.0.0
+  VERSION: 3.1.0
 
 steps:
-  - name: install
+  - name: setup
     image: node:24.18.0-alpine3.24@sha256:4ba75f835bb8802193e4c114572113d4b26f95f6f094f4b5229d2a77773e0afc
     commands:
       - yarn install
@@ -29,6 +29,8 @@ steps:
         include:
         - master
       event: [ push, pull_request, tag ]  
+    depends_on:
+      - setup
 
   - name: docker_build
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
@@ -44,6 +46,9 @@ steps:
         include:
         - master
       event: [ push, pull_request, tag ]
+    depends_on:
+      - setup
+      - test
 
   # Trivy Security Scannner
   - name: scan-base-image
@@ -56,7 +61,7 @@ steps:
     environment:
       IMAGE_NAME: node:24.18.0-alpine3.24@sha256:4ba75f835bb8802193e4c114572113d4b26f95f6f094f4b5229d2a77773e0afc
       SERVICE_URL: https://acp-trivy-helm.acp-trivy.svc.cluster.local:443 
-      TOLERATE: MEDIUM,HIGH,CRITICAL --vuln-type os,library
+      SEVERITY: MEDIUM,HIGH,CRITICAL --vuln-type os,library
       FAIL_ON_DETECTION: false
       IGNORE_UNFIXED: true
       ALLOW_CVE_LIST_FILE: cve-exceptions.txt
@@ -68,6 +73,32 @@ steps:
         include:
         - master
       event: [ push, pull_request, tag ]
+
+  # Trivy Security Scannner
+  - name: scan-post-build-image
+    pull: always
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
+    resources:
+      limits:
+        cpu: 1000
+        memory: 1024Mi
+    environment:
+      IMAGE_NAME: html-pdf-converter:${DRONE_COMMIT_SHA}
+      SERVICE_URL: https://acp-trivy-helm.acp-trivy.svc.cluster.local:443 
+      SEVERITY: MEDIUM,HIGH,CRITICAL --vuln-type os,library
+      FAIL_ON_DETECTION: false
+      IGNORE_UNFIXED: true
+      ALLOW_CVE_LIST_FILE: cve-exceptions.txt
+    volumes:
+      - name: dockersock
+        path: /var/run
+    when:
+      branch:
+        include:
+        - master
+      event: [ push, pull_request, tag ]
+    depends_on:
+      - docker_build
 
   - name: docker_push
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
@@ -83,30 +114,8 @@ steps:
         include:
         - master
       event: [ push, pull_request, tag ]
-
-  # Trivy Security Scannner
-  - name: scan-packages
-    pull: always
-    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
-    resources:
-      limits:
-        cpu: 1000
-        memory: 1024Mi
-    environment:
-      IMAGE_NAME: html-pdf-converter:${DRONE_COMMIT_SHA}
-      SERVICE_URL: https://acp-trivy-helm.acp-trivy.svc.cluster.local:443 
-      TOLERATE: MEDIUM,HIGH,CRITICAL --vuln-type os,library
-      FAIL_ON_DETECTION: false
-      IGNORE_UNFIXED: true
-      ALLOW_CVE_LIST_FILE: cve-exceptions.txt
-    volumes:
-      - name: dockersock
-        path: /var/run
-    when:
-      branch:
-        include:
-        - master
-      event: [ push, pull_request, tag ]
+    depends_on:
+      - scan-post-build-image
 
 services:
   - name: docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,29 @@
-FROM node:24-slim
+FROM node:24.18.0-alpine3.24@sha256:4ba75f835bb8802193e4c114572113d4b26f95f6f094f4b5229d2a77773e0afc
 
+ENV PUPPETEER_SKIP_DOWNLOAD=true \
+	PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
-# Update package index and upgrade all installed packages
-RUN apt-get update && apt-get upgrade -y
-
-# Upgrade bundled npm deps so Trivy does not report vulnerable tar/undici from base image toolchain
-RUN npm install -g npm@12.0.1 && npm --version
-
-# Install latest chrome dev package, which installs the necessary libs to
-# make the bundled version of Chromium that Puppeteer installs work.
-RUN apt-get install -y curl gnupg --no-install-recommends
-RUN curl -k https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-RUN apt-get update
-RUN apt-get install -y google-chrome-unstable --no-install-recommends
-
-RUN addgroup --system app
-RUN adduser --system app --uid 999 --home /app/
-RUN adduser app app
-RUN chown -R app:app /app/
+RUN apk update && apk upgrade \
+	&& apk add --no-cache chromium nss freetype harfbuzz ca-certificates ttf-freefont \
+	&& corepack enable \
+	&& corepack prepare yarn@1.22.22 --activate \
+	&& npm install -g npm@latest \
+	&& npm --version \
+	&& yarn --version \
+	&& rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx \
+	&& addgroup -S app \
+	&& adduser -S -u 999 -G app -h /app app \
+	&& mkdir -p /app \
+	&& chown -R app:app /app \
+	&& test -x /usr/bin/chromium-browser || ln -s /usr/bin/chromium /usr/bin/chromium-browser
 
 USER 999
 WORKDIR /app
 
-COPY package.json /app/package.json
-RUN yarn install --frozen-lockfile --production --ignore-optional
-
-# ensure user can exec the chrome binaries installed into the puppeteer directory
-RUN chown -R app:app /app/node_modules/puppeteer
+COPY package.json yarn.lock /app/
+RUN yarn install --frozen-lockfile --production --ignore-optional \
+	&& chown -R app:app /app/node_modules/puppeteer
 
 COPY . /app
 
-CMD node --unhandled-rejections=strict index.js
+CMD ["node", "--unhandled-rejections=strict", "index.js"]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Navigate to quay.io/ukhomeofficedigital/html-pdf-converter to find latest the ta
 For example, if the latest tagged version v2.4.3 then this command will need to be run:
 
 ```bash
-docker pull quay.io/ukhomeofficedigital/html-pdf-converter:v2.4.3 
+docker pull quay.io/ukhomeofficedigital/html-pdf-converter:v3.1.0 
 ```
 Once completed you can check the image is available locally by running: 
 ```bash 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "html-pdf-converter",
   "description": "An HTML to PDF conversion service wrapper",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "license": "MIT",
   "author": "Aditya Babu Mallisetti",
   "repository": "git+https://github.com/UKHomeOffice/html-pdf-converter.git",
@@ -11,7 +11,7 @@
   "homepage": "https://github.com/UKHomeOffice/html-pdf-converter#readme",
   "main": "index.js",
   "engines": {
-    "node": ">=24 <25"
+    "node": ">=24.18.0 <25.0.0"
   },
   "scripts": {
     "start": "node .",
@@ -43,6 +43,7 @@
   },
   "resolutions": {
     "serialize-javascript": "^7.0.7",
-    "diff": "^8.0.4"
+    "diff": "^8.0.4",
+    "brace-expansion": "5.0.8"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -151,11 +151,11 @@
     "@babel/helper-validator-identifier" "^7.29.7"
 
 "@eslint-community/eslint-utils@^4.2.0":
-  version "4.10.0"
-  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.10.0.tgz#fce5e18a889081035823343081f45e99a2d7288c"
-  integrity sha512-rd6n9Sefya1R1Vd594TRwzeHq2VnmICbvh3jebyt1Hs/6OoCSYNVpjGRRsKSTwAq3SKl09w0AfRCU57hoDLmxg==
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz#8911bd72b2c3640a543609e0400b8c4d2e7e7cb6"
+  integrity sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==
   dependencies:
-    eslint-visitor-keys "^5.0.1"
+    eslint-visitor-keys "^3.4.3"
 
 "@eslint-community/regexpp@^4.6.1":
   version "4.12.2"
@@ -608,11 +608,6 @@ b4a@^1.6.4, b4a@^1.8.1:
   resolved "https://registry.yarnpkg.com/b4a/-/b4a-1.8.1.tgz#7f16334ca80127aeb26064a28841acbf174840a4"
   integrity sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==
 
-balanced-match@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
-  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
-
 balanced-match@^4.0.2:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
@@ -656,9 +651,9 @@ bare-url@^2.2.2:
     bare-path "^3.0.0"
 
 baseline-browser-mapping@^2.10.44:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.11.0.tgz#25453328838032c7a514fbd238a171f744e9e854"
-  integrity sha512-oCu2wfipvX3AePSgmOuKkIywOu+8n9psz7hXYmk56ghpu3+7KzNIBopaOs4c9BrtdnTtW30unG9GTfHo7EwERQ==
+  version "2.11.4"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.11.4.tgz#3da1a877a8be2ec06495123ce994b43af58cc55e"
+  integrity sha512-s4+sLr9mZ/CyqeRritFeYV/Zx73OAtmaHn6kkBS1XRoJn1hrg3xIDUcpicAEX68tkcIN0iBCgti31C8zxtkhsQ==
 
 basic-ftp@^5.0.2:
   version "5.3.1"
@@ -703,25 +698,10 @@ body-parser@^2.2.1:
     raw-body "^3.0.2"
     type-is "^2.1.0"
 
-brace-expansion@^1.1.7:
-  version "1.1.16"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.16.tgz#723d3a30c0558c225abc9fc479a73e14e26c3c2f"
-  integrity sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==
-  dependencies:
-    balanced-match "^1.0.0"
-    concat-map "0.0.1"
-
-brace-expansion@^2.0.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.2.tgz#0bba2271feb7d458b0d31ad13625aaa4754431e2"
-  integrity sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==
-  dependencies:
-    balanced-match "^1.0.0"
-
-brace-expansion@^5.0.5:
-  version "5.0.7"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.7.tgz#1b0e46965b479dad65af737b4a02790a05498337"
-  integrity sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==
+brace-expansion@5.0.8, brace-expansion@^1.1.7, brace-expansion@^2.0.2, brace-expansion@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.8.tgz#135ad0d8d808eb18eb5e0ec9a21f3a0b92ef18cf"
+  integrity sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==
   dependencies:
     balanced-match "^4.0.2"
 
@@ -911,11 +891,6 @@ component-emitter@^1.3.1:
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.1.tgz#ef1d5796f7d93f135ee6fb684340b26403c97d17"
   integrity sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==
 
-concat-map@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
-  integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
-
 content-disposition@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-1.1.0.tgz#f3db789c752d45564cc7e9e1e0b31790d4a38e17"
@@ -1093,15 +1068,10 @@ dezalgo@^1.0.4:
     asap "^2.0.0"
     wrappy "1"
 
-diff@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-7.0.0.tgz#3fb34d387cd76d803f6eebea67b921dab0182a9a"
-  integrity sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==
-
-diff@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-9.0.0.tgz#297c31cd7c280f13dfe335791ec2063bd4a73a6f"
-  integrity sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==
+diff@^7.0.0, diff@^8.0.4, diff@^9.0.0:
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-8.0.4.tgz#4f5baf3188b9b2431117b962eb20ba330fadf696"
+  integrity sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -1149,9 +1119,9 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.5.393:
-  version "1.5.395"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.395.tgz#b82e88344bdc9e5c00d280140e7ca278c7325661"
-  integrity sha512-7zt9Aw+SrmxLWLN0zhaTWZQiCdryLVrYTq5R7iZakLvi2UQPYMMsROYV/2qVCzMeCiSXHwKOU+sZ4zOVVlrtKA==
+  version "1.5.396"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.396.tgz#4aa96428486c8d1c9c8aeb205b2d6e04928ca046"
+  integrity sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -1484,11 +1454,6 @@ eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
-eslint-visitor-keys@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz#9e3c9489697824d2d4ce3a8ad12628f91e9f59be"
-  integrity sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==
-
 eslint@^8.53.0, eslint@^8.57.1:
   version "8.57.1"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.57.1.tgz#7df109654aba7e3bbe5c8eae533c5e461d3c6ca9"
@@ -1737,9 +1702,9 @@ flat@^5.0.2:
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
 flatted@^3.2.9:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.2.tgz#f5c23c107f0f37de8dbdf24f13722b3b98d52726"
-  integrity sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.3.tgz#be5c21e943b2d7a328bb23795ae28c98f0103a9e"
+  integrity sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==
 
 for-each@^0.3.3, for-each@^0.3.5:
   version "0.3.5"
@@ -2107,9 +2072,9 @@ internal-slot@^1.1.0:
     side-channel "^1.1.0"
 
 ip-address@^10.1.1:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.2.0.tgz#805fc178b20c518bd4c8548b24fe30892d7f3206"
-  integrity sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==
+  version "10.3.1"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.3.1.tgz#929f9629d1724f7e1b7485ce89752f3675336a10"
+  integrity sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==
 
 ipaddr.js@1.9.1:
   version "1.9.1"
@@ -2489,9 +2454,9 @@ media-typer@0.3.0:
   integrity sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
 
 media-typer@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-1.1.0.tgz#6ab74b8f2d3320f2064b2a87a38e7931ff3a5561"
-  integrity sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-1.1.1.tgz#6f035400dfe3ab9d5607bc77546ce30cc2f9c6b8"
+  integrity sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==
 
 merge-descriptors@^2.0.0:
   version "2.0.0"
@@ -2995,13 +2960,6 @@ random-string@^0.2.0:
   resolved "https://registry.yarnpkg.com/random-string/-/random-string-0.2.0.tgz#a46e4375352beda9a0d7b0d19ed6d321ecd1d82d"
   integrity sha512-isA91IquV3ZrFbvwkAtExP8aGL+csx3KGEsEJrvCidzOHioPl5B5g7WyJlk0lMkEz5/i1PqrWTvcdtJHPtrp1g==
 
-randombytes@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
-  integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
-  dependencies:
-    safe-buffer "^5.1.0"
-
 range-parser@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.3.0.tgz#d7f19be812bb62721472b45d3be219ef09572b47"
@@ -3148,11 +3106,6 @@ safe-array-concat@^1.1.3:
     has-symbols "^1.1.0"
     isarray "^2.0.5"
 
-safe-buffer@^5.1.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
-  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
-
 safe-push-apply@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/safe-push-apply/-/safe-push-apply-1.0.0.tgz#01850e981c1602d398c85081f360e4e6d03d27f5"
@@ -3207,12 +3160,10 @@ send@^1.1.0, send@^1.2.0:
     range-parser "^1.2.1"
     statuses "^2.0.2"
 
-serialize-javascript@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
-  integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
-  dependencies:
-    randombytes "^2.1.0"
+serialize-javascript@^6.0.2, serialize-javascript@^7.0.7:
+  version "7.0.7"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.7.tgz#06ec40576d4cea96d68010a534520bff1f948a72"
+  integrity sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==
 
 serve-static@^2.2.0:
   version "2.2.1"


### PR DESCRIPTION
What?
This pull request updates the base image and dependencies to address security and compatibility, and improves the build pipeline for the `html-pdf-converter` service. Main changes include switching from a Debian-based Node.js image to a more secure and lightweight Alpine-based image, updating Puppeteer and Chromium setup, and tightening the Node.js version requirement. Drone CI configuration is also updated to use the same secure image and to enhance vulnerability scanning.

HOW?
**Docker image and build improvements:**
* Switched the base image in `Dockerfile` and `.drone.yml` from `node:24-slim` (Debian-based) to a specific, pinned `node:24.18.0-alpine3.24` image with a SHA256 digest for improved security, reproducibility, and smaller image size. Also updated the Chromium/Puppeteer installation steps to use Alpine packages and environment variables, replacing the previous Debian/apt-based setup. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R29) [[2]](diffhunk://#diff-b54b39f1afced2465e1f3641db9d5bbf4f3a7fcf890996dfedd3c197bcb7f8c7L14-R14) [[3]](diffhunk://#diff-b54b39f1afced2465e1f3641db9d5bbf4f3a7fcf890996dfedd3c197bcb7f8c7L24-R24)
* Updated the Docker build process to use `corepack` for Yarn management and removed unnecessary global npm binaries after installation for a cleaner image.

**Dependency and configuration updates:**
* Updated `package.json` to version `3.1.0`, tightened the Node.js engine requirement to `>=24.18.0 <25.0.0`, and added a resolution for `brace-expansion@5.0.8` to address a known vulnerability. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L14-R14) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L46-R47)
* Updated the example Docker pull command in `README.md` to reference the new version `v3.1.0`.

**CI/CD pipeline and security scanning:**
* Updated the `IMAGE_NAME` environment variable in `.drone.yml` to use the new pinned Node.js image, and enhanced the `TOLERATE` variable with `--vuln-type os,library` for more comprehensive vulnerability scanning with Trivy. [[1]](diffhunk://#diff-b54b39f1afced2465e1f3641db9d5bbf4f3a7fcf890996dfedd3c197bcb7f8c7L57-R59) [[2]](diffhunk://#diff-b54b39f1afced2465e1f3641db9d5bbf4f3a7fcf890996dfedd3c197bcb7f8c7L98-R98)…e unavailable


Why?

This work is part of core cloud migration where High and Criticals are not allowed.
Vulnerabilities that are part of OS image are now reported in scan reports in Drone
Debian didnt have security patches for the vulnerabilties Hence used the same base image that is currenlty being used by all HOF services and micro services. 




