### PR TITLE
HOFF-2216: Update GitHub Actions workflows

### DIFF
--- a/.github/workflows/build-scan-push.yml
+++ b/.github/workflows/build-scan-push.yml
@@ -13,24 +13,42 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
-  build-scan:
+  build-scan-hofnotprod:
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     permissions:
       contents: read
       id-token: write
 
-    # Pinned to the commit behind tag 1.5.1 for supply-chain immutability.
     uses: Home-Office-Digital/core-cloud-workflow-docker-actions/.github/workflows/build-scan-push.yml@a3ef4252eb4877ca410e9296d7c2fc381c7ae8bf
 
     with:
       working_directory: "."
       dockerfile: "Dockerfile"
-
       image_name: "hof/html-pdf-converter"
-
       image_tag: "${{ github.event_name == 'pull_request' && format('pr-{0}-{1}', github.event.pull_request.number, github.event.pull_request.head.sha) || (startsWith(github.ref, 'refs/tags/') && github.ref_name) || github.sha }}"
-
-      tag_latest: ${{ github.ref == 'refs/heads/main' }}
+      tag_latest: ${{ github.event_name != 'pull_request' }}
 
     secrets:
-      AWS_ECR_ACCOUNT_ID: ${{ secrets.AWS_ECR_ACCOUNT_ID }}
-      ROLE_TO_ASSUME: ${{ startsWith(secrets.ROLE_TO_ASSUME, 'arn:aws:iam::') && secrets.ROLE_TO_ASSUME || format('arn:aws:iam::{0}:role/{1}', secrets.AWS_ECR_ACCOUNT_ID, secrets.ROLE_TO_ASSUME) }}
+      AWS_ECR_ACCOUNT_ID: ${{ secrets.HOFNOTPROD_AWS_ECR_ACCOUNT_ID }}
+      ROLE_TO_ASSUME: ${{ secrets.HOFNOTPROD_ROLE_TO_ASSUME }}
+      EXEMPTIONS_APP_ID: ${{ secrets.EXEMPTIONS_APP_ID }}
+      EXEMPTIONS_APP_PRIVATE_KEY: ${{ secrets.EXEMPTIONS_APP_PRIVATE_KEY }}
+
+  build-scan-hofprod:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: read
+      id-token: write
+
+    uses: Home-Office-Digital/core-cloud-workflow-docker-actions/.github/workflows/build-scan-push.yml@a3ef4252eb4877ca410e9296d7c2fc381c7ae8bf
+
+    with:
+      working_directory: "."
+      dockerfile: "Dockerfile"
+      image_name: "hof/html-pdf-converter"
+      image_tag: "${{ github.ref_name }}"
+      tag_latest: false
+
+    secrets:
+      AWS_ECR_ACCOUNT_ID: ${{ secrets.HOFPROD_AWS_ECR_ACCOUNT_ID }}
+      ROLE_TO_ASSUME: ${{ secrets.HOFPROD_ROLE_TO_ASSUME }}

--- a/.github/workflows/chart-lint-validate.yaml
+++ b/.github/workflows/chart-lint-validate.yaml
@@ -4,12 +4,11 @@ on:
   pull_request:
     branches:
       - main
-      - CCL-*
+
 
   push:
     branches:
       - main
-      - CCL-*
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Why

Docker images need to be built, scanned, and published to the correct ECR environment. Pull requests and main-branch builds should use the HOF notprod account, while versioned releases should publish to HOF prod.

The chart validation workflow also contained obsolete `CCL-*` branch triggers that were no longer aligned with the main-branch workflow.

## What

- Split the Docker workflow into separate `build-scan-hofnotprod` and `build-scan-hofprod` jobs.
- Publish pull request and `main` builds to the notprod ECR account.
- Publish version-tag builds to the prod ECR account.
- Retain the `hof/html-pdf-converter` image path and immutable reusable-workflow commit pin.
- Pass exemptions credentials to the notprod scanning job.
- Remove `CCL-*` triggers from the chart lint and validation workflow.

## How

The workflow calls the shared `core-cloud-workflow-docker-actions` build, scan, and push workflow:

- Pull requests use a `pr-<number>-<sha>` image tag and do not update `latest`.
- Pushes to `main` use the commit SHA and update `latest` in notprod.
- Version tags use the tag name and publish to prod without updating `latest`.
- AWS authentication uses environment-specific account IDs and IAM roles through GitHub Actions secrets and OIDC.

## Anything else

The following repository secrets must be configured before the new jobs can publish images:

- `HOFNOTPROD_AWS_ECR_ACCOUNT_ID`
- `HOFNOTPROD_ROLE_TO_ASSUME`
- `HOFPROD_AWS_ECR_ACCOUNT_ID`
- `HOFPROD_ROLE_TO_ASSUME`
- `EXEMPTIONS_APP_ID`
- `EXEMPTIONS_APP_PRIVATE_KEY`
